### PR TITLE
Fixes and new Command

### DIFF
--- a/MxHidDevice.h
+++ b/MxHidDevice.h
@@ -144,7 +144,7 @@ public:
 		unsigned long Data;
 	}ImgFormatDCDData, *PImgFormatDCDData;
 
-	enum eTask { INIT = 1, TRANS, EXEC, RUN, RUN_PLUGIN };
+	enum eTask { INIT = 1, TRANS, EXEC, JUMP, RUN, RUN_PLUGIN };
 	typedef struct _MxFunc
 	{
 		eTask Task;
@@ -177,6 +177,7 @@ public:
 	//BOOL ProgramFlash(std::ifstream& file, UINT address, UINT cmdID, UINT flags, Device::UI_Callback callback);
 	BOOL Download(UCHAR* pBuffer, ULONGLONG dataCount, PMxFunc pMxFunc);
 	BOOL Execute(UINT32 ImageStartAddr);
+	BOOL Jump(UINT RAMAddress);
 	BOOL MxHidDevice::RunPlugIn(UCHAR* pBuffer, ULONGLONG dataCount, PMxFunc pMxFunc);
 	//BOOL Reset();
 
@@ -231,7 +232,6 @@ private:
 	//void PackRklCommand(unsigned char *cmd, unsigned short cmdId, unsigned long addr, unsigned long param1, unsigned long param2);
 	//struct Response UnPackRklResponse(unsigned char *resBuf);
 	BOOL AddIvtHdr(UINT32 ImageStartAddr);
-	BOOL Jump(UINT RAMAddress);
 	BOOL TransData(UINT address, UINT byteCount, const unsigned char * pBuf);
 	BOOL ReadData(UINT address, UINT byteCount, unsigned char * pBuf);
 	BOOL WriteToDevice(const unsigned char *buf, UINT count);

--- a/sb_loader.cpp
+++ b/sb_loader.cpp
@@ -143,9 +143,20 @@ int _tmain(int argc, TCHAR* argv[], TCHAR* envp[])
 			case MxHidDevice::EXEC:
 				if (!g_pMxHidDevice->Execute(MxFunc.ImageParameter.PhyRAMAddr4KRL))
 				{
+					TRACE(__FUNCTION__ " ERROR: Exec RAM failed.\n");
+					_tprintf(_T("%  Failed to exec RAM.\n"), indent);
+					nRetCode = 4;
+					return nRetCode;
+				}
+				TRACE(__FUNCTION__ " Exec RAM successfully.\n");
+				_tprintf(_T("%sExec RAM successfully.\n"), indent);
+				break;
+			case MxHidDevice::JUMP:
+				if (!g_pMxHidDevice->Jump(MxFunc.ImageParameter.PhyRAMAddr4KRL))
+				{
 					TRACE(__FUNCTION__ " ERROR: Jump to RAM failed.\n");
 					_tprintf(_T("%  Failed to jump to RAM.\n"), indent);
-					nRetCode = 4;
+					nRetCode = 5;
 					return nRetCode;
 				}
 				TRACE(__FUNCTION__ " Jump to RAM successfully.\n");
@@ -361,6 +372,11 @@ bool ProcessCommandLine(int argc, TCHAR* argv[], CString& fwFilename, ExtendedFu
 			pMxFunc->Task = MxHidDevice::EXEC;
 			pMxFunc->ImageParameter.PhyRAMAddr4KRL = String2Uint(argv[++i]);
 		}
+		else if (arg.CompareNoCase(_T("-jump")) == 0 && i <= argc - 1)
+		{
+			pMxFunc->Task = MxHidDevice::JUMP;
+			pMxFunc->ImageParameter.PhyRAMAddr4KRL = String2Uint(argv[++i]);
+		}
 		else if (arg.CompareNoCase(_T("-nojump")) == 0 && i <= argc - 1)
 		{
 			pMxFunc->Task = MxHidDevice::RUN_PLUGIN;
@@ -397,6 +413,7 @@ void PrintUsage()
 		_T("\t-nojump - Load but don't execute the image in which plugin is contained to RAM. Available for mx50 and later.\n\n") \
 		_T("\t-trans - Load the image to RAM, the target address must be followed. Available for mx50 and later.\n\n") \
 		_T("\t-exec - Execute the image, the execution address must be followed. Available for mx50 and later.\n\n") \
+		_T("\t-jump - Jump to the image, the image address must be followed. Available for mx50 and later.\n\n") \
 		_T("\t-init - initialize RAM by using the settings defined in memoryinit.h. Available for mx50 and later.\n\n") \
 		_T("\tbelow instance download and run an image:\n") \
 		_T("\tsb_loader -f uboot.bin\n\n");

--- a/sb_loader.cpp
+++ b/sb_loader.cpp
@@ -394,10 +394,10 @@ void PrintUsage()
 		_T("\t-f or /f <filename> - where <filename> is the file to download. Default: \"firmware.sb\"\n\n") \
 		_T("\t-tss or /tss - captures and prints the TSS output after the file is downloaded.\n\n") \
 		_T("\t-h or /h - displays this screen.\n\n") \
-		_T("\t-nojump - Load but don't execute the image in which plugin is contained to RAM. Only available for mx50.\n\n") \
-		_T("\t-trans - Load the image to RAM, the target address must be followed. Only available for mx50.\n\n") \
-		_T("\t-exec - Execute the image, the execution address must be followed. Only available for mx50.\n\n") \
-		_T("\t-init - initialize RAM by using the settings defined in memoryinit.h. Only available for mx50.\n\n") \
+		_T("\t-nojump - Load but don't execute the image in which plugin is contained to RAM. Available for mx50 and later.\n\n") \
+		_T("\t-trans - Load the image to RAM, the target address must be followed. Available for mx50 and later.\n\n") \
+		_T("\t-exec - Execute the image, the execution address must be followed. Available for mx50 and later.\n\n") \
+		_T("\t-init - initialize RAM by using the settings defined in memoryinit.h. Available for mx50 and later.\n\n") \
 		_T("\tbelow instance download and run an image:\n") \
 		_T("\tsb_loader -f uboot.bin\n\n");
 

--- a/sb_loader.cpp
+++ b/sb_loader.cpp
@@ -142,8 +142,12 @@ int _tmain(int argc, TCHAR* argv[], TCHAR* envp[])
 				break;
 			case MxHidDevice::EXEC:
 				if (!g_pMxHidDevice->Execute(MxFunc.ImageParameter.PhyRAMAddr4KRL))
+				{
+					TRACE(__FUNCTION__ " ERROR: Jump to RAM failed.\n");
+					_tprintf(_T("%  Failed to jump to RAM.\n"), indent);
 					nRetCode = 4;
-
+					return nRetCode;
+				}
 				TRACE(__FUNCTION__ " Jump to RAM successfully.\n");
 				_tprintf(_T("%sJump to RAM successfully.\n"), indent);
 				break;


### PR DESCRIPTION
This fixes a error handling issue I stumbled upon and clarifies that most features are also available on newer SoC (such as i.MX6...)

Furthermore it also adds a new command jump which is useful for images which already come with a IVT header.
