### PR TITLE
Fix array indexing while trying to access IVT

### DIFF
--- a/MxHidDevice.cpp
+++ b/MxHidDevice.cpp
@@ -537,7 +537,7 @@ BOOL MxHidDevice::RunMxMultiImg(UCHAR* pBuffer, ULONGLONG dataCount)
 	}
 
 	pImg += ImageOffset / sizeof(DWORD);
-	if (pImg[ImgIVTOffset] != MX8_IVT_BARKER_HEADER && pImg[ImgIVTOffset] != MX8_IVT2_BARKER_HEADER)
+	if (pImg[ImgIVTOffset / sizeof(DWORD)] != MX8_IVT_BARKER_HEADER && pImg[ImgIVTOffset / sizeof(DWORD)] != MX8_IVT2_BARKER_HEADER)
 	{
 		TRACE(_T("Not a valid image.\n"));
 		return FALSE;
@@ -545,7 +545,7 @@ BOOL MxHidDevice::RunMxMultiImg(UCHAR* pBuffer, ULONGLONG dataCount)
 
 	pIVT = (PIvtHeaderV2)(pImg + ImgIVTOffset / sizeof(DWORD));
 
-	if (pImg[ImgIVTOffset] == MX8_IVT2_BARKER_HEADER)
+	if (pImg[ImgIVTOffset / sizeof(DWORD)] == MX8_IVT2_BARKER_HEADER)
 	{
 		pIVT2 = (PIvtHeaderV2)(pImg + ImgIVTOffset + pIVT->Next / sizeof(DWORD));
 	}


### PR DESCRIPTION
While checking for the IVT header the pointer pImg was being accessed as an array
to the offset where the IVT was supposed to be but the indexing was being done
without resizing the offset with respect its type (offset / sizeof(offset).

Signed-off-by: Manuel Rodriguez <manuel.rodriguez@nxp.com>